### PR TITLE
refactor: replace custom heading text size in partners

### DIFF
--- a/src/components/Partners.tsx
+++ b/src/components/Partners.tsx
@@ -163,7 +163,7 @@ const Partners: React.FC<PartnersProps> = ({ className }) => {
                 <div className="grid gap-6 md:grid-cols-2">
                     <FadeIn>
                         <div className="rounded-3xl bg-white/30 p-8 backdrop-blur-3xl md:p-10">
-                            <p className="mb-6 text-center text-[11px] font-semibold tracking-[0.25em] text-gray-500">
+                            <p className="mb-6 text-center text-xs font-semibold tracking-[0.25em] text-gray-500 md:text-sm lg:text-base">
                                 ORGANIZED BY
                             </p>
                             <div className="mx-auto flex max-w-xs items-center justify-center">
@@ -173,7 +173,7 @@ const Partners: React.FC<PartnersProps> = ({ className }) => {
                     </FadeIn>
                     <FadeIn delay={80}>
                         <div className="rounded-3xl bg-white/30 p-8 backdrop-blur-3xl md:p-10">
-                            <p className="mb-6 text-center text-[11px] font-semibold tracking-[0.25em] text-gray-500">
+                            <p className="mb-6 text-center text-xs font-semibold tracking-[0.25em] text-gray-500 md:text-sm lg:text-base">
                                 SPONSORED BY
                             </p>
                             <div className="mx-auto flex max-w-xs items-center justify-center">
@@ -186,7 +186,7 @@ const Partners: React.FC<PartnersProps> = ({ className }) => {
                 {/* Community Partners Carousel */}
                 <FadeIn delay={140}>
                     <div className="mt-6 rounded-3xl bg-white/30 p-6 backdrop-blur-3xl md:mt-8 md:p-10">
-                        <p className="mb-6 text-center text-[11px] font-semibold tracking-[0.25em] text-gray-500">
+                        <p className="mb-6 text-center text-xs font-semibold tracking-[0.25em] text-gray-500 md:text-sm lg:text-base">
                             COMMUNITY PARTNERS
                         </p>
                         <div className="overflow-hidden">


### PR DESCRIPTION
### **User description**
## Summary
- replace ad-hoc `text-[11px]` headings with responsive token classes in Partners component

## Testing
- `npm run lint` *(fails: Unknown options: useEslintrc, extensions, resolvePluginsRelativeTo, rulePaths, ignorePath, reportUnusedDisableDirectives)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c61b884e9c832cacf3993e1cac1cc9


___

### **PR Type**
Enhancement


___

### **Description**
- Replace custom `text-[11px]` with responsive Tailwind classes

- Add responsive typography scaling across breakpoints

- Improve heading consistency in Partners component


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Custom text-[11px]"] -- "refactor" --> B["Responsive text-xs/sm/base"]
  B --> C["Better mobile/desktop scaling"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Partners.tsx</strong><dd><code>Replace custom text sizes with responsive tokens</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/components/Partners.tsx

<ul><li>Replace three instances of <code>text-[11px]</code> with responsive classes<br> <li> Add <code>text-xs md:text-sm lg:text-base</code> for better scaling<br> <li> Update headings for "ORGANIZED BY", "SPONSORED BY", and "COMMUNITY <br>PARTNERS"</ul>


</details>


  </td>
  <td><a href="https://github.com/CeyLabs/Web3Ceylon-Web-FE/pull/26/files#diff-18a8b6bfca22351404519ea728b552e532320cd97798ea762d25a2c30eab330a">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

