### PR TITLE
refactor: use tailwind text size tokens in footer

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -79,10 +79,10 @@ export default function Footer() {
                                     className="font-secondary flex w-full items-center justify-between rounded-2xl px-5 py-4 text-left font-normal transition-colors hover:bg-white/40 focus:bg-white/40"
                                     aria-label={`${item.label}: ${item.display}`}
                                 >
-                                    <span className="text-[15px] text-[#3b3b3b] sm:text-[16px]">
+                                    <span className="text-sm text-[#3b3b3b] sm:text-base">
                                         {item.label}
                                     </span>
-                                    <span className="flex items-center justify-end gap-2 text-[15px] font-medium text-[#4a4a4a] sm:text-[16px]">
+                                    <span className="flex items-center justify-end gap-2 text-sm font-medium text-[#4a4a4a] sm:text-base">
                                         {item.display}
                                         <ArrowUpRight
                                             className="inline-block h-4 w-4"
@@ -102,10 +102,10 @@ export default function Footer() {
                                     className="font-secondary flex w-full items-center justify-between rounded-2xl px-5 py-4 text-left font-normal transition-colors hover:bg-white/40 focus:bg-white/40"
                                     aria-label={`${item.label}: ${item.display}`}
                                 >
-                                    <span className="text-[15px] text-[#3b3b3b] sm:text-[16px]">
+                                    <span className="text-sm text-[#3b3b3b] sm:text-base">
                                         {item.label}
                                     </span>
-                                    <span className="text-[15px] font-medium text-[#4a4a4a] sm:text-[16px]">
+                                    <span className="text-sm font-medium text-[#4a4a4a] sm:text-base">
                                         {item.display}
                                     </span>
                                 </a>


### PR DESCRIPTION
### **User description**
## Summary
- replace pixel-based footer text sizes with Tailwind tokens for consistency

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Invalid options: useEslintrc, extensions, resolvePluginsRelativeTo, rulePaths, ignorePath, reportUnusedDisableDirectives)*

------
https://chatgpt.com/codex/tasks/task_e_68c61bd6b948832c9b1c698efab0b32a


___

### **PR Type**
Enhancement


___

### **Description**
- Replace pixel-based text sizes with Tailwind tokens

- Update footer component for design system consistency


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Footer Component"] --> B["Replace text-[15px] with text-sm"]
  A --> C["Replace text-[16px] with text-base"]
  B --> D["Consistent Design System"]
  C --> D
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Footer.tsx</strong><dd><code>Replace pixel sizes with Tailwind tokens</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/components/Footer.tsx

<ul><li>Replace <code>text-[15px]</code> with <code>text-sm</code> for mobile text sizes<br> <li> Replace <code>text-[16px]</code> with <code>text-base</code> for desktop text sizes<br> <li> Apply changes to both volunteer button and link elements<br> <li> Maintain responsive design with <code>sm:</code> prefix</ul>


</details>


  </td>
  <td><a href="https://github.com/CeyLabs/Web3Ceylon-Web-FE/pull/27/files#diff-0dce242c6c493ad784b03374bef9541bc63a42693fdb79e88c6dda5e76fbac04">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

