### PR TITLE
Display countdown timers in four vertical rows

### DIFF
--- a/src/components/CountdownTicker.tsx
+++ b/src/components/CountdownTicker.tsx
@@ -167,8 +167,8 @@ const CountdownTicker: React.FC<TickerProps> = ({
     const bgBaseInflow = "rounded-2xl border border-white/20 backdrop-blur-3xl bg-white/30";
     const inFlowWrapperClasses = `fixed bottom-0 left-0 right-0 z-50 px-4 py-3 sm:px-6 sm:py-4 md:px-8 md:py-5 sm:bg-[#F6F4D5] transition-[opacity,max-height] duration-200 overflow-hidden relative ${
         stickyActive ? "opacity-0" : "opacity-100"
-    } ${showMultiple ? "flex gap-2 justify-center" : ""}`;
-    const contentClassesInflow = `group block ${showMultiple ? "flex-1" : "w-full"} ${bgBaseInflow} px-6 py-3 sm:px-6 sm:py-4 min-h-12 text-black hover:bg-white/15 transition-all duration-300 ${
+    } ${showMultiple ? "flex flex-col gap-2" : ""}`;
+    const contentClassesInflow = `group block w-full ${bgBaseInflow} px-6 py-3 sm:px-6 sm:py-4 min-h-12 text-black hover:bg-white/15 transition-all duration-300 ${
         className ?? ""
     }`;
     const contentClassesSticky = `group block w-full px-5 py-2.5 sm:px-5 sm:py-3 min-h-10`;
@@ -176,10 +176,12 @@ const CountdownTicker: React.FC<TickerProps> = ({
     const event1 = event;
     const event2 = cityEvents[(index + 1) % cityEvents.length];
     const event3 = cityEvents[(index + 2) % cityEvents.length];
+    const event4 = cityEvents[(index + 3) % cityEvents.length];
 
     const { isLive: isLive1, ended: ended1, countdown: countdown1 } = useEventState(event1);
     const { isLive: isLive2, ended: ended2, countdown: countdown2 } = useEventState(event2);
     const { isLive: isLive3, ended: ended3, countdown: countdown3 } = useEventState(event3);
+    const { isLive: isLive4, ended: ended4, countdown: countdown4 } = useEventState(event4);
 
     const renderEventContent = (
         event: CityEvent,
@@ -268,10 +270,11 @@ const CountdownTicker: React.FC<TickerProps> = ({
                 {/* Content */}
                 <div className="relative z-20">
                     {showMultiple ? (
-                        <div className="flex justify-center gap-2">
+                        <div className="flex flex-col gap-2">
                             {renderEventContent(event1, "inflow", isLive1, ended1, countdown1)}
                             {renderEventContent(event2, "inflow", isLive2, ended2, countdown2)}
                             {renderEventContent(event3, "inflow", isLive3, ended3, countdown3)}
+                            {renderEventContent(event4, "inflow", isLive4, ended4, countdown4)}
                         </div>
                     ) : (
                         renderContent("inflow")


### PR DESCRIPTION
### **User description**
## Summary
- stack multiple countdown events vertically instead of horizontally
- show four event timers at once when multiple countdowns are displayed

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unknown options: useEslintrc, extensions, resolvePluginsRelativeTo, rulePaths, ignorePath, reportUnusedDisableDirectives)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c6f7c24f10832cb903d3849ad7e522


___

### **PR Type**
Enhancement


___

### **Description**
- Change countdown timer layout from horizontal to vertical rows

- Display four countdown events instead of three

- Update CSS classes for vertical stacking layout


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Horizontal Layout"] --> B["Vertical Layout"]
  C["3 Events"] --> D["4 Events"]
  B --> E["Four Vertical Rows"]
  D --> E
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CountdownTicker.tsx</strong><dd><code>Convert horizontal countdown layout to vertical four-row display</code></dd></summary>
<hr>

src/components/CountdownTicker.tsx

<ul><li>Modified CSS classes to use <code>flex-col</code> for vertical stacking instead of <br>horizontal<br> <li> Added fourth event (<code>event4</code>) with corresponding state hooks<br> <li> Updated wrapper classes to remove <code>flex-1</code> and use full width for each <br>timer<br> <li> Added rendering for the fourth countdown event in the multiple events <br>display</ul>


</details>


  </td>
  <td><a href="https://github.com/CeyLabs/Web3Ceylon-Web-FE/pull/39/files#diff-876de9b05b4f02db74bbf0d4ce94cde58c9b4b437ac2074d522cf10ab9bc3114">+6/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

